### PR TITLE
Erklärung auf einer rechten Seite

### DIFF
--- a/arbeit.tex
+++ b/arbeit.tex
@@ -200,7 +200,7 @@ Dieses Werk ist unter der Creative Commons Attribution-NonCommercial-ShareAlike 
 \bibliography{bibliography}
 
 
-\clearpage
+\cleardoublepage
 \thispagestyle{empty}
 
 Name: \fullname \hfill Matrikelnummer: \matnr \vspace{2cm}


### PR DESCRIPTION
Die Erklärung sollte auf einem eigenen Blatt Papier sein, daher
mittels \cleardoublepage auf die nächste rechte Seite schieben.
